### PR TITLE
tweaks to map and directions

### DIFF
--- a/src/Directions.js
+++ b/src/Directions.js
@@ -1,12 +1,17 @@
 import React from 'react';
 
 function Directions(props) {
+    var gmaps_link;
+    if (props.origin) {
+        gmaps_link = <GoogleDirections origin={props.origin} destination={props.destination} />
+    } else {
+        gmaps_link = <GoogleMaps destination={props.destination} />
+    }
+
     return (
         <div id="directions">
             <br/>
-            <GoogleMaps destination={props.destination} />
-            { props.origin && <span> or </span> }
-            { props.origin && <OpenStreetMap origin={props.origin} destination={props.destination} /> }
+            { gmaps_link }
         </div>
     );
 }
@@ -17,10 +22,10 @@ function GoogleMaps(props) {
            </a>
 }
 
-function OpenStreetMap(props) {
-    return <a href={"https://www.openstreetmap.org/directions?engine=mapzen_foot&route=" + props.origin + ";" + props.destination} target="_top">
-               show me directions
+function GoogleDirections(props) {
+    return <a href={"https://maps.google.com/maps/dir/" + props.origin + '/' + props.destination} target="_top">
+               Show me directions
            </a>
 }
 
-export { Directions, GoogleMaps, OpenStreetMap };
+export { Directions, GoogleMaps, GoogleDirections };

--- a/src/Directions.test.js
+++ b/src/Directions.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import 'jest-enzyme';
-import { Directions, GoogleMaps, OpenStreetMap } from './Directions';
+import { Directions, GoogleMaps, GoogleDirections } from './Directions';
 
 describe('Directions', () => {
 
@@ -14,14 +14,14 @@ describe('Directions', () => {
         const wrapper = shallow(<Directions destination={params.destination}/>);
 
         expect(wrapper).toContainReact(<GoogleMaps destination={456}/>);
-        expect(wrapper).not.toContainReact(<OpenStreetMap/>);
+        expect(wrapper).not.toContainReact(<GoogleDirections/>);
     });
 
-    it('renders OpenStreetMap directions when destination and origin present', () => {
+    it('renders only Google Directions when destination and origin present', () => {
         const wrapper = shallow(<Directions destination={params.destination} origin={params.origin}/>);
 
-        expect(wrapper).toContainReact(<GoogleMaps destination={456}/>);
-        expect(wrapper).toContainReact(<OpenStreetMap destination={456} origin={123}/>);
+        expect(wrapper).not.toContainReact(<GoogleMaps/>);
+        expect(wrapper).toContainReact(<GoogleDirections destination={456} origin={123}/>);
     });
 
 });


### PR DESCRIPTION
* standardise on google maps
* show only directions if we have both src and dst points
* show only map if we only have a destination point

possible future work: As noted in https://github.com/DemocracyClub/UK-Polling-Stations/pull/1037#issuecomment-316040845 and https://github.com/DemocracyClub/UK-Polling-Stations/issues/1043 we might also look at showing an apple maps link to iOS users and google maps links to everyone else. If we do that on WhereDIV, we should reflect it in the widget, but its still up under consideration. If you use iOS, feedback welcome..