### PR TITLE
run build script before tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
 before_script:
   - npm install
 script:
+  - npm run build
   - npm run coverage
 after_script:
   - COVERALLS_REPO_TOKEN=$coveralls_repo_token npm run coveralls


### PR DESCRIPTION
If we change something that breaks our build process, travis should warn us about it.

This becomes particularly relevant if we start adding more steps into the build pipeline (e.g: #41 )