### PR TITLE
override explicit select height styles in parent page

### DIFF
--- a/src/AddressPicker.js
+++ b/src/AddressPicker.js
@@ -31,7 +31,7 @@ class AddressPicker extends React.Component {
                     <div>
                         <div className="form-group">
                             <label className="form-label-bold">Choose your address</label>
-                            <select value={this.state.value} onChange={this.setAddress} aria-describedby="address_picker" className="select_multirow" id="id_address" name="address" size="5">
+                            <select value={this.state.value} onChange={this.setAddress} aria-describedby="address_picker" className="democracy_club_select_multirow" id="id_address" name="address" size="5">
                             {
                                 this.props.addressList.map(this.addressOption)
                             }

--- a/wdiv.css
+++ b/wdiv.css
@@ -119,3 +119,6 @@
     padding:1rem 2rem 1.0625rem 2rem;
     text-transform:none
 }
+.democracy_club_select_multirow {
+    height: auto !important;
+}


### PR DESCRIPTION
`<Chris attempts to do CSS>`
This seems like it might be a good idea
Closes #46
`</Chris attempts to do CSS>`

I think the previous `className="select_multirow"` was probably just copy + pased from somewhere rather than actually being semantically useful?