### PR TITLE
use content negotiation header to request json

### DIFF
--- a/src/WdivAPI.js
+++ b/src/WdivAPI.js
@@ -1,7 +1,9 @@
 function API(client) {
 
+    client.defaults.headers.get['Content-Type'] = 'application/json';
+
     function toUrl(postcode) {
-        return 'https://wheredoivote.co.uk/api/beta/postcode/' + postcode + '.json';
+        return 'https://wheredoivote.co.uk/api/beta/postcode/' + postcode;
     }
 
     function addAnalytics() {
@@ -14,11 +16,11 @@ function API(client) {
 
     return {
         getPollingStation: function(postcode) {
-            return client.get(toUrl(postcode) + "?" + addAnalytics())
+            return client.get(toUrl(postcode) + "?" + addAnalytics());
         },
 
         getFromSelector: function(url) {
-            return client.get(url.substring(0, url.length - 1) + '.json')
+            return client.get(url);
         },
 
         toAddress: function(output) {

--- a/src/WdivAPI.test.js
+++ b/src/WdivAPI.test.js
@@ -19,7 +19,7 @@ describe('WhereDoIVote API client', () => {
         api.getPollingStation("T3 5TS").catch((err) => {});
 
         var requestUrl = axios.get.getCall(0).args[0];
-        expect(requestUrl).toMatch("https://wheredoivote.co.uk/api/beta/postcode/T3 5TS.json");
+        expect(requestUrl).toMatch("https://wheredoivote.co.uk/api/beta/postcode/T3 5TS");
     });
 
     it('adds metadata to show where it has been embedded', () => {
@@ -28,16 +28,16 @@ describe('WhereDoIVote API client', () => {
         api.getPollingStation("T3 5TS").catch((err) => {});
 
         var requestUrl = axios.get.getCall(0).args[0];
-        expect(requestUrl).toMatch("T3 5TS.json?utm_source=localhost&utm_medium=widget");
+        expect(requestUrl).toMatch("T3 5TS?utm_source=localhost&utm_medium=widget");
     });
 
-    it('requests from selector by removing last character and adding JSON extension', () => {
+    it('requests from selector', () => {
         var api = new API(axios);
 
         api.getFromSelector("https://wheredoivote.co.uk/some_path/").catch((err) => {});
 
         var requestUrl = axios.get.getCall(0).args[0];
-        expect(requestUrl).toEqual("https://wheredoivote.co.uk/some_path.json");
+        expect(requestUrl).toEqual("https://wheredoivote.co.uk/some_path/");
     });
 
     describe('address transformation', () => {


### PR DESCRIPTION
We don't need to use string manipulation to append `.json` to URLs if we want to instruct the API we want json. As long as we're requesting `application/json` and not `text/html` in the request, it will send us the right content.