### PR TITLE
fix: Remove deprecated APIs in favour of newer methods to mount CSS

### DIFF
--- a/src/Widget.js
+++ b/src/Widget.js
@@ -88,7 +88,7 @@ class Widget extends Component {
 
     }
 
-    componentWillMount() {
+    componentDidMount() {
         const link = document.createElement("link");
         link.rel = 'stylesheet';
         link.href = 'https://widget.wheredoivote.co.uk/wdiv.css';


### PR DESCRIPTION
Fixes: #101

Running it locally shows a tiny 'flicker' as it loads the CSS - I don't have a strong opinion on whether this is a problem or not.

I also spiked an alternative below (inspired by a web extension I'm working on at the moment) to load the css first but there was no noticeable difference when running locally - the flicker is still present.

```javascript
(function() {

    function loadCss() {
        const link = document.createElement("link");
        link.rel = 'stylesheet';
        link.href = 'https://widget.wheredoivote.co.uk/wdiv.css';
        link.type = 'text/css';

        document.head.appendChild(link);
    }

    if(window.wdiv_widget_rendered) {
        return;
    } else {
        window.wdiv_widget_rendered = true;
    }

    loadCss();
    ReactDOM.render(<Widget />, document.getElementById('dc_wdiv'))
}());
```