### PR TITLE
Use up-to-date React Shadow

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,11 +1,6 @@
 update_configs:
   -
     directory: /
-    ignored_updates:
-      -
-        match:
-          dependency_name: react-shadow
-          version_requirement: ">=17.0.0"
     package_manager: javascript
     update_schedule: daily
 version: 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -7733,6 +7733,11 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
+    "humps": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/humps/-/humps-2.0.1.tgz",
+      "integrity": "sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao="
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -12005,6 +12010,11 @@
         "ipaddr.js": "1.9.0"
       }
     },
+    "proxy-polyfill": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/proxy-polyfill/-/proxy-polyfill-0.3.0.tgz",
+      "integrity": "sha512-0HN+SoV3qKJ1EIIOsEybYgyTTnR26PJ0af/shBqaXLUMIg7/8PHEyQ28QfaDFwmvH77yRuLtclnERgrCq4v+xg=="
+    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -12443,9 +12453,12 @@
       }
     },
     "react-shadow": {
-      "version": "16.3.2",
-      "resolved": "https://registry.npmjs.org/react-shadow/-/react-shadow-16.3.2.tgz",
-      "integrity": "sha512-NxFoBvEg2WD3V25jgiWgIltpDfs2XBCbDyi63jEM6Gch8g8r2cqJxSWy2GfG666EfOpRR5Zsrhu0Qn5yze1PrA=="
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/react-shadow/-/react-shadow-17.1.3.tgz",
+      "integrity": "sha512-T0TETccduTNwid9/URfWRhtAH0Fv3eA1zra7cq+2bY5u4fd4oBjtXA629h/95QN8aznlJof3ELd36qOyzaGdHQ==",
+      "requires": {
+        "humps": "^2.0.1"
+      }
     },
     "react-test-renderer": {
       "version": "16.10.2",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "dependencies": {
     "axios": "^0.19.0",
     "es6-shim": "^0.35.5",
+    "proxy-polyfill": "^0.3.0",
     "react": "^16.10.2",
     "react-app-polyfill": "^1.0.4",
     "react-dom": "^16.10.2",
-    "react-shadow": "16.3.2"
+    "react-shadow": "^17.1.3"
   },
   "devDependencies": {
     "@baristalabs/react-app-rewire-raw-loader": "^0.1.3",

--- a/src/ShadowDomFactory.js
+++ b/src/ShadowDomFactory.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ShadowDOM from 'react-shadow';
+import root from 'react-shadow';
 
 function ShadowDomFactory(props) {
   function shouldUseShadowDom() {
@@ -11,7 +11,7 @@ function ShadowDomFactory(props) {
 
   return (
     <>
-      {shouldUseShadowDom() ? <ShadowDOM>{props.children}</ShadowDOM> : <div>{props.children}</div>}
+      {shouldUseShadowDom() ? <root.div>{props.children}</root.div> : <div>{props.children}</div>}
     </>
   );
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import 'es6-shim';
 import 'react-app-polyfill/ie9';
 import 'react-app-polyfill/ie11';
+import 'proxy-polyfill';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import DemocracyClubWidget from './DemocracyClubWidget';


### PR DESCRIPTION
Managed to get it all running with the latest version of react-shadow.

The eagle-eyed will notice that we're not actually using the Polyfill in IE11, rather we're serving it a standard div element on line 14 of src/ShadowDomFactory.js. However, failure to include the proxy-polyfill JS code in src/index.js will lead to IE11 blowing up and displaying a blank white screen (breaking the website containing the widget). Therefore, we include the polyfill to ensure it renders in IE11, but we don't actually get the benefits of Shadow Dom in that browser – not the end of the world.