### PR TITLE
Tweaks/layout enhancements

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,7 +18,7 @@
       .column {
         float: left;
         position: relative;
-        width: 50%;
+        width: 33%;
 
         box-sizing: border-box;
         padding: 10px;
@@ -104,7 +104,31 @@
         tempor. Sed venenatis eu nisl eu eleifend.
       </div>
 
- 
+      <div class="column column-three">
+        Phasellus tristique eros ac quam malesuada pulvinar. Ut fringilla hendrerit ultricies. Aliquam bibendum tellus
+        vel turpis vehicula faucibus. Etiam a commodo urna. Ut finibus lacinia orci, sed pellentesque nunc congue ac.
+        Etiam tristique faucibus rhoncus. Cras consequat placerat nisl. Duis placerat convallis nisi, ac tempor ex
+        laoreet ac. Sed volutpat elit non auctor accumsan. Sed dictum luctus lacus, sit amet ullamcorper mauris maximus
+        a.
+
+        Nunc sagittis, urna sed tristique pellentesque, nulla nibh fermentum diam, et sollicitudin libero augue non
+        tortor. Maecenas varius consectetur nisl, sed rhoncus enim volutpat nec. Nulla viverra vitae libero a semper.
+        Interdum et malesuada fames ac ante ipsum primis in faucibus. Vivamus ac nisl eu metus tempus interdum at sed
+        dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec pharetra rutrum mauris, sit amet fermentum
+        sem consectetur mollis. Proin sollicitudin quis ex dapibus porttitor. Sed et turpis interdum, ornare sem
+        tristique, iaculis ante. Suspendisse aliquet a urna non tempor. Vestibulum consequat erat ultrices mattis
+        tempus.
+
+        Suspendisse aliquam mattis nibh id pellentesque. Fusce consectetur auctor sapien, nec iaculis sapien laoreet
+        nec. Aenean ullamcorper ante eget quam cursus bibendum. Quisque facilisis tristique justo. Nulla pellentesque
+        mauris a feugiat congue. Nulla tincidunt, dui id finibus rhoncus, orci massa maximus odio, eget efficitur purus
+        quam sagittis augue. Cras ultrices tellus neque, ac lacinia turpis tempus vel. Aliquam sollicitudin porttitor
+        viverra. Vivamus sed sem a turpis dictum volutpat. Aliquam consectetur ut ligula eu condimentum. Sed arcu massa,
+        auctor nec sem ut, aliquam varius erat. Mauris neque lectus, finibus vitae augue ut, imperdiet congue metus. Nam
+        fermentum nunc urna, at semper mi auctor quis. Sed elementum mauris eget varius rutrum. Praesent id orci ac ex
+        fermentum dapibus.
+
+      </div>
     </div>
   </main>
 </body>

--- a/public/index.html
+++ b/public/index.html
@@ -18,7 +18,7 @@
       .column {
         float: left;
         position: relative;
-        width: 33%;
+        width: 50%;
 
         box-sizing: border-box;
         padding: 10px;
@@ -104,31 +104,7 @@
         tempor. Sed venenatis eu nisl eu eleifend.
       </div>
 
-      <div class="column column-three">
-        Phasellus tristique eros ac quam malesuada pulvinar. Ut fringilla hendrerit ultricies. Aliquam bibendum tellus
-        vel turpis vehicula faucibus. Etiam a commodo urna. Ut finibus lacinia orci, sed pellentesque nunc congue ac.
-        Etiam tristique faucibus rhoncus. Cras consequat placerat nisl. Duis placerat convallis nisi, ac tempor ex
-        laoreet ac. Sed volutpat elit non auctor accumsan. Sed dictum luctus lacus, sit amet ullamcorper mauris maximus
-        a.
-
-        Nunc sagittis, urna sed tristique pellentesque, nulla nibh fermentum diam, et sollicitudin libero augue non
-        tortor. Maecenas varius consectetur nisl, sed rhoncus enim volutpat nec. Nulla viverra vitae libero a semper.
-        Interdum et malesuada fames ac ante ipsum primis in faucibus. Vivamus ac nisl eu metus tempus interdum at sed
-        dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec pharetra rutrum mauris, sit amet fermentum
-        sem consectetur mollis. Proin sollicitudin quis ex dapibus porttitor. Sed et turpis interdum, ornare sem
-        tristique, iaculis ante. Suspendisse aliquet a urna non tempor. Vestibulum consequat erat ultrices mattis
-        tempus.
-
-        Suspendisse aliquam mattis nibh id pellentesque. Fusce consectetur auctor sapien, nec iaculis sapien laoreet
-        nec. Aenean ullamcorper ante eget quam cursus bibendum. Quisque facilisis tristique justo. Nulla pellentesque
-        mauris a feugiat congue. Nulla tincidunt, dui id finibus rhoncus, orci massa maximus odio, eget efficitur purus
-        quam sagittis augue. Cras ultrices tellus neque, ac lacinia turpis tempus vel. Aliquam sollicitudin porttitor
-        viverra. Vivamus sed sem a turpis dictum volutpat. Aliquam consectetur ut ligula eu condimentum. Sed arcu massa,
-        auctor nec sem ut, aliquam varius erat. Mauris neque lectus, finibus vitae augue ut, imperdiet congue metus. Nam
-        fermentum nunc urna, at semper mi auctor quis. Sed elementum mauris eget varius rutrum. Praesent id orci ac ex
-        fermentum dapibus.
-
-      </div>
+ 
     </div>
   </main>
 </body>

--- a/src/CandidateItem.js
+++ b/src/CandidateItem.js
@@ -18,7 +18,6 @@ function CandidateItem(props) {
           {candidate.person.name}
         </a>
       </h2>
-      {' – '}
       <h3 className={`party-name party-${partyId}`}>{candidate.party.party_name}</h3>
     </li>
   );

--- a/src/CandidateItem.js
+++ b/src/CandidateItem.js
@@ -17,7 +17,7 @@ function CandidateItem(props) {
         >
           {candidate.person.name}
         </a>
-      </h2>
+      </h2>{' '}
       <h3 className={`party-name party-${partyId}`}>{candidate.party.party_name}</h3>
     </li>
   );

--- a/src/widget-styles.css
+++ b/src/widget-styles.css
@@ -529,6 +529,21 @@ footer {
   font-weight: normal;
 }
 
+@media (min-width: 25em) {
+  .candidate-name::after {
+    content: " – ";
+  }
+}
+
+@media (max-width: 25em) {
+  .Candidates li {
+    margin-bottom: 0.35rem;
+  }
+  .party-name {
+    display: block;
+  }
+}
+
 .party-name::before {
   content: '';
   width: 0.75rem;

--- a/src/widget-styles.css
+++ b/src/widget-styles.css
@@ -171,7 +171,6 @@
   line-height: var(--dc-line-height-default);
   padding: 4px; /* Prevent .Card box-shadow clipping in `overflow: hidden` containers */
   text-align:left;
-  max-width: 25rem;
 }
 
 .Card {
@@ -529,22 +528,7 @@ footer {
   font-weight: normal;
 }
 
-@media (min-width: 25em) {
-  .candidate-name::after {
-    content: " – ";
-  }
-}
-
-@media (max-width: 25em) {
-  .Candidates li {
-    margin-bottom: 0.35rem;
-  }
-  .party-name {
-    display: block;
-  }
-}
-
-.party-name::before {
+.candidate-name::before {
   content: '';
   width: 0.75rem;
   height: 0.75rem;
@@ -566,43 +550,43 @@ footer {
   font-family: var(--dc-serif-font);
 }
 
-.party-52.party-name::before {
+.party-52.candidate-name::before {
   background: var(--party-colour-party-52);
 }
-.party-53.party-name::before {
+.party-53.candidate-name::before {
   background: var(--party-colour-party-53);
 }
-.party-53-119.party-name::before {
+.party-53-119.candidate-name::before {
   background: var(--party-colour-party-53-119);
 }
-.party-63.party-name::before {
+.party-63.candidate-name::before {
   background: var(--party-colour-party-63);
 }
-.party-90.party-name::before {
+.party-90.candidate-name::before {
   background: var(--party-colour-party-90);
 }
-.party-77.party-name::before {
+.party-77.candidate-name::before {
   background: var(--party-colour-party-77);
 }
-.party-102.party-name::before {
+.party-102.candidate-name::before {
   background: var(--party-colour-party-102);
 }
-.party-85.party-name::before {
+.party-85.candidate-name::before {
   background: var(--party-colour-party-85);
 }
 
-.party-39.party-name::before {
+.party-39.candidate-name::before {
   background: var(--party-colour-party-39);
 }
-.party-70.party-name::before {
+.party-70.candidate-name::before {
   background: var(--party-colour-party-70);
 }
-.party-83.party-name::before {
+.party-83.candidate-name::before {
   background: var(--party-colour-party-83);
 }
-  .party-55.party-name::before {
+  .party-55.candidate-name::before {
   background: var(--party-colour-party-55);  
    }  
-.party-103.party-name::before {
+.party-103.candidate-name::before {
   background: var(--party-colour-party-103);
  } 

--- a/src/widget-styles.css
+++ b/src/widget-styles.css
@@ -170,6 +170,8 @@
   font-family: var(--dc-sanserif-font);
   line-height: var(--dc-line-height-default);
   padding: 4px; /* Prevent .Card box-shadow clipping in `overflow: hidden` containers */
+  text-align:left;
+  max-width: 25rem;
 }
 
 .Card {
@@ -477,9 +479,8 @@ footer {
   }
 }
 .loading-spinner {
-  position: absolute;
-  top: 2.5rem;
-  right: 2.5rem;
+  position: relative;
+  margin: 2rem;
   opacity: 1;
   transition: opacity linear 0.1s;
 }


### PR DESCRIPTION
This PR ensures the widget never goes above a manageable size, and also that its text is aligned left. (When embedding on CanIVote.org.uk I discovered the Shadow Dom isn't as impregnable as I'd thought - the `text-align: center` of the containing element was affecting the widget.)

Finally, it addresses https://github.com/DemocracyClub/WhereDoIVote-Widget/issues/318 by only showing the en dash separating candidates from their party name on wider screens, and setting the party name to sit on its own line with a slightly increased margin below.

N.B. in the absence of a general solution for component level media queries, if the widget is embedded in a narrow column on a wider screen, the style improvements _won't apply_ as the media query is for the entire device width, rather than its containing element. Indeed, our own example embed code is an example of somewhere it won't work, until the three cols collapse to a single column.