### PR TITLE
All dependabots and npm audit fix fixes #401

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -2,5 +2,5 @@ update_configs:
   -
     directory: /
     package_manager: javascript
-    update_schedule: daily
+    update_schedule: weekly
 version: 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -13399,12 +13399,6 @@
         "lodash._reinterpolate": "^3.0.0"
       }
     },
-    "lodash.unescape": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
-      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
-      "dev": true
-    },
     "lodash.uniq": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",


### PR DESCRIPTION
This resolves terminal warning about manual fix for reported security vulnerabilities in npm packages.