### PR TITLE
Change logo source to svg

### DIFF
--- a/deploy-dc.sh
+++ b/deploy-dc.sh
@@ -37,4 +37,4 @@ JS_FILE=$(cat build/asset-manifest.json | jq -r '.files."main.js"')
 
 deploy-to-s3 ./build/${JS_FILE} dc_wdiv.js
 deploy-to-s3 ./demo.html demo.html
-deploy-to-s3 ./public/img/logo-with-text.png logo-with-text.png
+deploy-to-s3 ./public/img/logo.svg logo.svg

--- a/public/index.html
+++ b/public/index.html
@@ -63,7 +63,7 @@
     </div>
     <div class="container">
       <div class="column column-one">
-        <h3>Test postcodes</h3>
+        <h2>Test postcodes</h2>
         <p>For <strong>mock</strong> data, you can view <a
             href="https://github.com/DemocracyClub/WhereDoIVote-Widget/tree/master/public/example-responses"
             target="_blank">all the postcodes we currently have fixtures for on our Github</a></p>

--- a/src/dc-widget-styles.css
+++ b/src/dc-widget-styles.css
@@ -482,6 +482,16 @@ footer {
   text-align: left;
   padding-right: 0.5rem;
 }
+.DCLogoText {
+  font-size: var(--dc-font-size-smallest);
+  font-weight: 300;
+  line-height: 1;
+  margin-left: 0.25rem;
+  color:black;
+  text-align: left;
+  padding-right: 0.5rem;
+}
+
 
 /*--------------------------------------------------------------
 # Loading spinner

--- a/src/dc-widget-styles.css
+++ b/src/dc-widget-styles.css
@@ -482,15 +482,6 @@ footer {
   text-align: left;
   padding-right: 0.5rem;
 }
-.DCLogoText {
-  font-size: var(--dc-font-size-smallest);
-  font-weight: 300;
-  line-height: 1;
-  margin-left: 0.25rem;
-  color:black;
-  text-align: left;
-  padding-right: 0.5rem;
-}
 
 
 /*--------------------------------------------------------------


### PR DESCRIPTION
This fix adds an absolute logo source that is less pixelated (.svg vs .png) and text based. 
 
<img width="570" alt="Screen Shot 2022-03-03 at 9 19 27 AM" src="https://user-images.githubusercontent.com/7017118/156534712-8be8632d-8d6f-4aa8-9313-9197874ecbc7.png">

IE11



Firefox



Chrome




