### PR TITLE
Fix deploy scripts

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -96,7 +96,7 @@
             scrolling="no"></iframe>
         </noscript>
         <div id="dc_wdiv" data-elections="true" data-language="en" aria-live="polite" role="region"></div>
-        <script type="text/javascript" src="dc_wdiv.js"></script>
+        <script type="text/javascript" src="wdiv.js"></script>
         <br />
         Aliquam libero tortor, fermentum ut nibh quis, rutrum venenatis nisi. Cras aliquet dictum mollis. Aenean gravida
         dui nec nisl aliquam porttitor. Donec vitae egestas lacus. Integer malesuada tellus non semper eleifend. Cras

--- a/deploy-dc.sh
+++ b/deploy-dc.sh
@@ -36,6 +36,6 @@ npm run dc:build:prod
 
 JS_FILE=$(cat build/asset-manifest.json | jq -r '.files."main.js"')
 
-deploy-to-s3 ./build/${JS_FILE} dc_wdiv.js
+deploy-to-s3 ./build/${JS_FILE} wdiv.js
 deploy-to-s3 ./demo.html demo.html
 deploy-to-s3 ./public/img/logo-with-text.png logo-with-text.png

--- a/deploy-dc.sh
+++ b/deploy-dc.sh
@@ -32,6 +32,7 @@ deploy-to-s3() {
 }
 
 rm -rf build
+npm run dc:build:prod
 
 JS_FILE=$(cat build/asset-manifest.json | jq -r '.files."main.js"')
 

--- a/deploy-ec.sh
+++ b/deploy-ec.sh
@@ -32,6 +32,7 @@ deploy-to-s3() {
 }
 
 rm -rf build
+npm run ec:build:prod
 
 JS_FILE=$(cat build/asset-manifest.json | jq -r '.files."main.js"')
 

--- a/deploy-ec.sh
+++ b/deploy-ec.sh
@@ -36,6 +36,6 @@ npm run ec:build:prod
 
 JS_FILE=$(cat build/asset-manifest.json | jq -r '.files."main.js"')
 
-deploy-to-s3 ./build/${JS_FILE} dc_wdiv.js
+deploy-to-s3 ./build/${JS_FILE} ec_widget.js
 deploy-to-s3 ./demo.html demo.html
 deploy-to-s3 ./public/img/logo-with-text.png logo-with-text.png


### PR DESCRIPTION
https://github.com/DemocracyClub/WhereDoIVote-Widget/pull/561 was merged with some unresolved issues around the deploy scripts.

1. Neither of the deploy scripts actually build any assets - they just delete the build folder then try to deploy nothing
2. https://github.com/DemocracyClub/WhereDoIVote-Widget/pull/561#discussion_r589042674 was not really resolved. `deploy-dc.sh` is still trying to write a file called `dc_wdiv.js` to S3. Only the docs were changed.
3. `deploy-ec.sh` is also trying to write its output to a S3 file called `dc_wdiv.js` so whichever script you ran second would 'win'

This fixes those issues.