### PR TITLE
allow user to pre-populate postcode using data-postcode attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,19 @@ Default Welsh with option to toggle to English:
 <script type="text/javascript" src="https://widget.wheredoivote.co.uk/wdiv.js"></script>
 ```
 
+### Pre-populate a postcode
+
+If you already know the user's postcode, you can render the widget div with the postcode pre-populated.
+This will take the user straight to their results (or an address picker).
+
+```html
+<noscript>
+  <a href="https://whocanivotefor.co.uk/">Information about elections in your area</a>
+</noscript>
+<div id="dc_wdiv" data-postcode="SW1A 1AA" data-language="en" aria-live="polite" role="region"></div>
+<script type="text/javascript" src="https://widget.wheredoivote.co.uk/wdiv.js"></script>
+```
+
 ## Node Verion Manager (NVM)
 
 Similarly to pyenv, nvm is a tool to manage multiple versions of node. 

--- a/src/ElectionInformationWidget.js
+++ b/src/ElectionInformationWidget.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 
 import { StartAgainButton, ErrorMessage, Loader } from './Branding';
 
@@ -130,6 +130,16 @@ function ElectionInformationWidget(props) {
     }
     setAddressList(undefined);
   }
+
+  useEffect(() => {
+    const el = document.getElementById('dc_wdiv');
+    const initPostcode = el.getAttribute('data-postcode');
+
+    if (initPostcode) {
+      setSearchInitiated(true);
+      lookupGivenPostcode(initPostcode);
+    }
+  }, [lookupGivenPostcode]);
 
   return (
     <ShadowDomFactory>

--- a/src/ElectionInformationWidget.js
+++ b/src/ElectionInformationWidget.js
@@ -24,8 +24,9 @@ import AdvanceVoting from './AdvanceVoting';
 import EC_styles from '!!raw-loader!./ec-widget-styles.css'; // eslint-disable-line
 import DC_styles from '!!raw-loader!./dc-widget-styles.css'; // eslint-disable-line
 
+const api = APIClientFactory();
+
 function ElectionInformationWidget(props) {
-  const api = APIClientFactory();
   const [searchInitiated, setSearchInitiated] = useState(false);
   const [loading, setLoading] = useState(false);
   const [currentError, setCurrentError] = useState(undefined);
@@ -106,7 +107,7 @@ function ElectionInformationWidget(props) {
       }
       setLoading(false);
     },
-    [api, props.enableElections]
+    [props.enableElections]
   );
 
   const lookupGivenPostcode = useCallback(
@@ -116,7 +117,7 @@ function ElectionInformationWidget(props) {
       setCurrentError(undefined);
       api.fetchByPostcode(postcode).then(handleResponse).catch(handleError);
     },
-    [api, handleResponse]
+    [handleResponse]
   );
 
   function lookupChosenAddress(value) {

--- a/src/tests/integration/ElectionInformationWidget.test.js
+++ b/src/tests/integration/ElectionInformationWidget.test.js
@@ -8,6 +8,7 @@ import {
   renderEnglishWidget,
   renderElectionsWidget,
   renderLegacyWidget,
+  renderWidgetWithPostcode,
   typePostcode,
   submitPostcode,
   mockResponse,
@@ -459,6 +460,18 @@ describe('ElectionInformationWidget Legacy Candidates Widget', () => {
     submitPostcode();
     const Widget = await waitForElement(() => document.querySelector('.ElectionInformationWidget'));
     expect(Widget).toHaveTextContent('Candidates');
+  });
+});
+
+describe('ElectionInformationWidget with pre-populated postcode', () => {
+  it('should skip stright to result if postcode pre-populated', async () => {
+    const postcode = 'AA12AA';
+    mockResponse('postcode', postcode);
+    renderWidgetWithPostcode(postcode);
+    const YourPollingStation = await waitForElement(() =>
+      document.querySelector('.PollingStation')
+    );
+    expect(YourPollingStation).toHaveTextContent(en_messages['station.your-station']);
   });
 });
 

--- a/src/tests/utils/test.js
+++ b/src/tests/utils/test.js
@@ -69,3 +69,9 @@ export const renderLegacyWidget = () => {
   const wrapper = render(<ElectionInformationWidget />);
   return wrapper;
 };
+
+export const renderWidgetWithPostcode = (postcode) => {
+  render(<div id="dc_wdiv" data-postcode={postcode} aria-live="polite" role="region" />);
+  const wrapper = render(<ElectionInformationWidget />);
+  return wrapper;
+};


### PR DESCRIPTION
Closes #284

I went with doing this via a `data-` attribute as that is consistent with how all other configuration is done.

Some notes on this. No big surprises here, but:

- If the parent page pre-populates an invalid postcode, this will drop you to the "Please enter a valid postcode" error with a search box.
- If the parent page pre-populates a postcode that warrants showing an address picker, this will drop you straight to the address picker.
- If the parent page pre-populates a valid postcode, that will drop you straight to the results.

I think that's probably fine for an MVP, but the widget kind of "talks to the user" as if they initiated the search, but in this case they didn't. We might consider changing some of the messaging if we know the postcode was pre-populated, but I haven't done it here.

One example of something we might do (which would be quite simple) would be to hide the "back to postcode search" button if the postcode was pre-populated. I'm in 2 minds about it. Any thoughts on that one?
