### PR TITLE
fix spacing issue in photo id text

### DIFF
--- a/src/PollingDate.js
+++ b/src/PollingDate.js
@@ -92,7 +92,7 @@ function PollingDate(props) {
       {voter_id_requirements === 'EA-2022' && (
         <p>
           {' '}
-          You’ll need to take photo ID with you if you’re voting in person.
+          You’ll need to take photo ID with you if you’re voting in person.{' '}
           <a href="https://www.electoralcommission.org.uk/voting-and-elections/voter-id/accepted-forms-photo-id">
             Check the list of accepted forms of photo ID.
           </a>
@@ -101,7 +101,7 @@ function PollingDate(props) {
       {voter_id_requirements === 'EFA-2002' && (
         <p>
           {' '}
-          You’ll need to take photo ID with you if you’re voting in person.
+          You’ll need to take photo ID with you if you’re voting in person.{' '}
           <a href="https://www.eoni.org.uk/Vote/Voting-at-a-polling-place">
             Check the list of accepted forms of photo ID.
           </a>


### PR DESCRIPTION
This PR fixes a minor spacing issue.

**Before:**

![spacing-before](https://github.com/DemocracyClub/WhereDoIVote-Widget/assets/6025893/c486818e-3dbb-4edb-a2e1-8a97d05f0eaa)

**After:**

![spacing-after](https://github.com/DemocracyClub/WhereDoIVote-Widget/assets/6025893/036c5737-c658-4197-b7f5-1149e3c106c7)
