### PR TITLE
Replace ballot_title with election_name and post

### DIFF
--- a/src/Ballot.js
+++ b/src/Ballot.js
@@ -17,7 +17,7 @@ function Ballot(props) {
             🗳️
           </span>
         )}{' '}
-        {ballot.ballot_title}
+        {ballot.election_name}: {ballot.post_name}
       </h2>
       <BallotInfo {...props} />
     </li>

--- a/src/Ballot.js
+++ b/src/Ballot.js
@@ -5,6 +5,10 @@ import BallotInfo from './BallotInfo';
 function Ballot(props) {
   const ballot = props.ballot;
   const candidatesVerified = ballot.candidates.length > 1 && ballot.candidates_verified;
+  const isConstituency = ['parl', 'senedd', 'sp.c'].some((prefix) =>
+    ballot.ballot_paper_id.startsWith(prefix)
+  );
+  const isRegion = ['senedd.r', 'sp.r'].some((prefix) => ballot.ballot_paper_id.startsWith(prefix));
   return (
     <li className="Ballot" data-testid={ballot.ballot_paper_id}>
       <h2 className={`eiw-secondary-header ${!candidatesVerified && 'full-width'}`}>
@@ -18,6 +22,8 @@ function Ballot(props) {
           </span>
         )}{' '}
         {ballot.election_name}: {ballot.post_name}
+        {isConstituency ? ' Constituency' : ''}
+        {isRegion ? ' Region' : ''}
       </h2>
       <BallotInfo {...props} />
     </li>

--- a/src/tests/integration/ElectionInformationWidget.test.js
+++ b/src/tests/integration/ElectionInformationWidget.test.js
@@ -442,7 +442,7 @@ describe('ElectionInformationWidget Everything Widget', () => {
     typePostcode(enteredPostcode);
     submitPostcode();
     const Widget = await waitForElement(() => document.querySelector('.ElectionInformationWidget'));
-    expect(Widget).toHaveTextContent('Tendring local election St Osyth');
+    expect(Widget).toHaveTextContent('Tendring local election: St Osyth');
     expect(Widget).toHaveTextContent(
       'The poll for this election has been rescheduled due to the sad death of one of the candidates.'
     );

--- a/src/tests/unit/EverythingWidgetComponents.test.js
+++ b/src/tests/unit/EverythingWidgetComponents.test.js
@@ -124,6 +124,40 @@ describe('Ballot Component', () => {
     );
     expect(BallotComponent).not.toHaveTextContent('Candidates');
   });
+
+  it('should render the ballot information for a region', () => {
+    const ballot = {
+      ballot_paper_id: 'senedd.r.2022-05-06',
+      cancelled: false,
+      election_name: 'Welsh Election',
+      post_name: 'South Wales',
+      candidates: ['Candidate 1', 'Candidate 2'],
+      candidates_verified: true,
+    };
+
+    const { getByTestId, getByText } = renderWithReactIntl(<Ballot ballot={ballot} />);
+
+    expect(getByTestId('senedd.r.2022-05-06')).toBeInTheDocument();
+    expect(getByText('🗳️ Welsh Election: South Wales Region')).toBeInTheDocument();
+    expect(getByText('Region')).toBeInTheDocument();
+  });
+
+  it('should render the ballot information for a constituency', () => {
+    const ballot = {
+      ballot_paper_id: 'senedd.2022-05-06',
+      cancelled: false,
+      election_name: 'Welsh Election',
+      post_name: 'Cardiff Central',
+      candidates: ['Candidate 1', 'Candidate 2'],
+      candidates_verified: true,
+    };
+
+    const { getByTestId, getByText } = renderWithReactIntl(<Ballot ballot={ballot} />);
+
+    expect(getByTestId('senedd.2022-05-06')).toBeInTheDocument();
+    expect(getByText('🗳️ Welsh Election: Cardiff Central Constituency')).toBeInTheDocument();
+    expect(getByText('Constituency')).toBeInTheDocument();
+  });
 });
 
 describe('PartyList Component', () => {


### PR DESCRIPTION
Ref https://app.asana.com/0/1204880927741389/1207520352598615/f and https://github.com/DemocracyClub/WhereDoIVote-Widget/issues/665

This work covers labels for: parl.*, senedd.c.*, sp.c.* senedd.r.* and sp.r.*

Additional work is needed to expose the `election_subtype` in the [postcode search results](https://developers.democracyclub.org.uk/api/v1/#postcode-search-results-found-4) to handle local and mayoral labels.
 
![Screenshot 2024-06-20 at 10 02 13 AM](https://github.com/DemocracyClub/WhereDoIVote-Widget/assets/7017118/bc62e94c-ac17-4ea0-8806-379eed5255b6)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207399869194220
  - https://app.asana.com/0/0/1207590323650584