### PR TITLE
Match widget text to WDIV

### DIFF
--- a/src/PollingDate.js
+++ b/src/PollingDate.js
@@ -41,7 +41,7 @@ function PollingDate(props) {
       className={`PollingDate date-${props.single ? 'single' : 'multiple'}`}
     >
       {props.single && (
-        <>
+        <div>
           <h1 data-testid={`title-date-${date.date}`} className="eiw-header">
             {dayMonthYear}
           </h1>
@@ -56,7 +56,7 @@ function PollingDate(props) {
               />
             </p>
           )}
-        </>
+        </div>
       )}
       {!props.single &&
         (activeBallots.length ? (
@@ -88,24 +88,36 @@ function PollingDate(props) {
           />
         </p>
       )}
-      {voter_id_requirements && <h3>Voter ID</h3>}
-      {voter_id_requirements === 'EA-2022' && (
-        <p>
-          {' '}
-          You’ll need to take photo ID with you if you’re voting in person.{' '}
-          <a href="https://www.electoralcommission.org.uk/voting-and-elections/voter-id/accepted-forms-photo-id">
-            Check the list of accepted forms of photo ID.
-          </a>
-        </p>
+      {voter_id_requirements && (
+        <div>
+          <h3>
+            <FormattedMessage id="voter_id_requirements.header" description="Voter ID" />
+          </h3>
+        </div>
       )}
-      {voter_id_requirements === 'EFA-2002' && (
-        <p>
-          {' '}
-          You’ll need to take photo ID with you if you’re voting in person.{' '}
-          <a href="https://www.eoni.org.uk/Vote/Voting-at-a-polling-place">
-            Check the list of accepted forms of photo ID.
-          </a>
-        </p>
+      {voter_id_requirements === 'EA-2022' && (
+        <div>
+          <p>
+            <FormattedMessage
+              id="voter_id_requirements.instructions"
+              description="You will need to take photo ID to vote at a polling station in this election. You do not need your poll card to vote. You must vote at your assigned polling station."
+            />
+            <a href="https://www.electoralcommission.org.uk/voting-and-elections/voter-id/accepted-forms-photo-id">
+              <FormattedMessage
+                id="voter_id_requirements.acceptable-id"
+                description="Check the list of accepted forms of photo ID."
+              />
+            </a>
+          </p>
+          <p>
+            <a href="https://www.gov.uk/how-to-vote">
+              <FormattedMessage
+                id="voter_id_requirements.how-to-vote"
+                description="Read more about voting in Great Britain."
+              />
+            </a>
+          </p>
+        </div>
       )}
     </section>
   );

--- a/src/translations/cy.json
+++ b/src/translations/cy.json
@@ -63,5 +63,9 @@
   "uncontested.fewer_candidates.not_zero": "Bydd etholiad newydd i lenwi'r {seat_or_seats} na hawliwyd yn cael ei gynnal o fewn 35 diwrnod gwaith i ddyddiad gwreiddiol yr etholiad.",
   "cancelled.header": "Etholiad Wedi'i Ganslo",
   "cancelled.message": "Canslwyd yr etholiad hwn.",
-  "cancelled.rescheduled.header":"Etholiad Heb Ymgeisydd ac Etholiad wedi'i Aildrefnu"
+  "cancelled.rescheduled.header":"Etholiad Heb Ymgeisydd ac Etholiad wedi'i Aildrefnu",
+  "voter_id_requirements.header": "ID Pleidleisiwr",
+  "voter_id_requirements.instructions": "Bydd angen i chi dynnu llun ID i bleidleisio mewn gorsaf bleidleisio yn yr etholiad hwn. Nid oes angen eich cerdyn pleidleisio arnoch i bleidleisio. Rhaid i chi bleidleisio yn eich gorsaf bleidleisio benodedig. ",
+  "voter_id_requirements.acceptable-id": "Gwiriwch y rhestr o ffurfiau derbyniol o ID llun. ",
+  "voter_id_requirements.how-to-vote": "Darllenwch fwy am bleidleisio ym Mhrydain Fawr."
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -63,5 +63,9 @@
   "uncontested.fewer_candidates.not_zero": "A new election to fill the unclaimed {seat_or_seats} will be held within 35 working days of the original election date.",
   "cancelled.header": "Cancelled Election",
   "cancelled.message": "This election was cancelled.",
-  "cancelled.rescheduled.header":"Uncontested and Rescheduled Election"
+  "cancelled.rescheduled.header":"Uncontested and Rescheduled Election",
+  "voter_id_requirements.header": "Voter ID",
+  "voter_id_requirements.instructions": "You will need to take photo ID to vote at a polling station in this election. You do not need your poll card to vote. You must vote at your assigned polling station. ",
+  "voter_id_requirements.acceptable-id": "Check the list of accepted forms of photo ID. ",
+  "voter_id_requirements.how-to-vote": "Read more about voting in Great Britain."
 }


### PR DESCRIPTION
This change:

- matches text to WDIV
- adds Welsh translation for Voter ID requirements. 


![Screenshot 2024-06-26 at 10 28 01 AM](https://github.com/DemocracyClub/WhereDoIVote-Widget/assets/7017118/17c0c077-0d20-4a9b-b269-95cd23b32a7c)


![Screenshot 2024-06-26 at 10 31 44 AM](https://github.com/DemocracyClub/WhereDoIVote-Widget/assets/7017118/1aa8e8a0-f674-4ab0-b83f-7f458e87db17)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207520352598615
  - https://app.asana.com/0/0/1207644055255242