### PR TITLE
add dots to id prefixes

### DIFF
--- a/src/Ballot.js
+++ b/src/Ballot.js
@@ -5,10 +5,12 @@ import BallotInfo from './BallotInfo';
 function Ballot(props) {
   const ballot = props.ballot;
   const candidatesVerified = ballot.candidates.length > 1 && ballot.candidates_verified;
-  const isConstituency = ['parl', 'nia', 'gla.c', 'senedd.c', 'sp.c'].some((prefix) =>
+  const isConstituency = ['parl.', 'nia.', 'gla.c.', 'senedd.c.', 'sp.c.'].some((prefix) =>
     ballot.ballot_paper_id.startsWith(prefix)
   );
-  const isRegion = ['senedd.r', 'sp.r'].some((prefix) => ballot.ballot_paper_id.startsWith(prefix));
+  const isRegion = ['senedd.r.', 'sp.r.'].some((prefix) =>
+    ballot.ballot_paper_id.startsWith(prefix)
+  );
   let divisionType = '';
   if (isConstituency) {
     divisionType = 'Constituency';


### PR DESCRIPTION
Quick drive-by while I was working on something else.

The reason I want to change this is:

Next year, the Senedd will abolish the constituencies and regions setup and move to a single set of subdivisions. Depending on how we do the IDs, we may well end up with IDs that start `senedd.r` or `senedd.c` where that is just a new subdivision that starts with the letter "r" or "c".

While we're at it, lets do something similar for all the others..