### PR TITLE
show correct opening times for City of London local elections

### DIFF
--- a/public/example-responses/000_README.md
+++ b/public/example-responses/000_README.md
@@ -72,6 +72,17 @@ replicating various standard and edge cases cases we need to handle:
   - **uses postcode-CO168EZ.json**
   - edited to have parl.2019-12-12 as primary ballot ID for testing cancelled election
 
+## City of London
+
+- EC2Y8BT
+  - **uses postcode-EC2Y8BT.json**
+  - Single City of London local election ballot
+
+City of London local elections are different from other local elections in England in several ways. For example:
+  - Voter ID requirements 
+  - Polling station opening hours
+  - Election timetable (registration date, SOPN publish date, etc)
+
 # Candidates
 
 ## Lots of candidates for General Election

--- a/public/example-responses/postcode-EC2Y8BT.json
+++ b/public/example-responses/postcode-EC2Y8BT.json
@@ -1,0 +1,80 @@
+{
+  "address_picker": false,
+  "addresses": [],
+  "dates": [
+    {
+      "date": "2025-03-20",
+      "polling_station": {
+        "polling_station_known": false,
+        "custom_finder": null,
+        "report_problem_url": null,
+        "station": null
+      },
+      "advance_voting_station": null,
+      "notifications": [],
+      "ballots": [
+        {
+          "ballot_paper_id": "local.city-of-london.aldersgate.2025-03-20",
+          "ballot_title": "City of London local election Aldersgate",
+          "poll_open_date": "2025-03-20",
+          "elected_role": "Local Councillor",
+          "metadata": null,
+          "cancelled": false,
+          "cancellation_reason": null,
+          "replaced_by": null,
+          "replaces": null,
+          "requires_voter_id": null,
+          "ballot_url": "https://developers.democracyclub.org.uk/api/v1/elections/local.city-of-london.aldersgate.2025-03-20/",
+          "election_id": "local.city-of-london.2025-03-20",
+          "election_name": "City of London local election",
+          "post_name": "Aldersgate",
+          "candidates_verified": false,
+          "candidates": [],
+          "wcivf_url": "http://whocanivotefor.co.uk/elections/local.city-of-london.aldersgate.2025-03-20/aldersgate/",
+          "voting_system": {
+            "slug": "FPTP",
+            "name": "First-past-the-post",
+            "uses_party_lists": false
+          },
+          "seats_contested": 6,
+          "hustings": null,
+          "postal_voting_requirements": "EA-2022"
+        }
+      ]
+    }
+  ],
+  "electoral_services": {
+    "council_id": "LND",
+    "name": "City of London Corporation",
+    "email": "electoralservices@cityoflondon.gov.uk",
+    "phone": "0800 587 5537",
+    "website": "http://www.cityoflondon.gov.uk/",
+    "postcode": "EC2P 2EJ",
+    "address": "Electoral Registration Officer\nPO Box 270\nGuildhall",
+    "identifiers": [
+      "E09000001"
+    ],
+    "nation": "England"
+  },
+  "registration": {
+    "email": "electoralservices@cityoflondon.gov.uk",
+    "phone": "0800 587 5537",
+    "website": "http://www.cityoflondon.gov.uk/",
+    "postcode": "EC2P 2EJ",
+    "address": "Electoral Registration Officer\nPO Box 270\nGuildhall",
+    "identifiers": [
+      "E09000001"
+    ]
+  },
+  "postcode_location": {
+    "type": "Feature",
+    "properties": null,
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        -0.0960009,
+        51.5190294
+      ]
+    }
+  }
+}

--- a/src/ElectionInformationWidget.js
+++ b/src/ElectionInformationWidget.js
@@ -26,6 +26,15 @@ import DC_styles from '!!raw-loader!./dc-widget-styles.css'; // eslint-disable-l
 
 const api = APIClientFactory();
 
+function getOpeningTimes(ballots) {
+  for (const ballot of ballots) {
+    if (ballot.election_id.startsWith('local.city-of-london.')) {
+      return { start: 8, end: 8 };
+    }
+  }
+  return { start: 7, end: 10 };
+}
+
 function ElectionInformationWidget(props) {
   const [searchInitiated, setSearchInitiated] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -40,6 +49,7 @@ function ElectionInformationWidget(props) {
   const [uprn, setUPRN] = useState(undefined);
   const [dates, setDates] = useState(undefined);
   const [electoralServices, setElectoralServices] = useState(undefined);
+  const [openingTimes, setOpeningTimes] = useState(undefined);
   const dataSource = process.env.REACT_APP_API;
 
   function resetWidget() {
@@ -54,6 +64,7 @@ function ElectionInformationWidget(props) {
     setCurrentError(undefined);
     setLoading(false);
     setDates(undefined);
+    setOpeningTimes(undefined);
   }
 
   function handleError(data) {
@@ -105,6 +116,11 @@ function ElectionInformationWidget(props) {
       } else {
         setNoUpcomingElection(true);
       }
+
+      if (nextBallotDate && nextBallotDate.ballots) {
+        setOpeningTimes(getOpeningTimes(nextBallotDate.ballots));
+      }
+
       setLoading(false);
     },
     [props.enableElections]
@@ -187,10 +203,15 @@ function ElectionInformationWidget(props) {
               postcode={postcode}
               uprn={uprn}
               electoralServices={electoralServices}
+              openingTimes={openingTimes}
             />
           )}
           {stationNotFound && (
-            <StationNotFound notifications={notifications} electoral_services={electoralServices} />
+            <StationNotFound
+              notifications={notifications}
+              electoral_services={electoralServices}
+              openingTimes={openingTimes}
+            />
           )}
           {noUpcomingElection && (
             <NoUpcomingElection

--- a/src/PollingStation.js
+++ b/src/PollingStation.js
@@ -23,19 +23,24 @@ function PollingStation(props) {
     splitAddress.push(<br key={index} />);
   });
   return (
-    <section className="PollingStation">
+    <section className="PollingStation" data-testid="station-found">
       <h2 className="eiw-secondary-header">
         <FormattedMessage id="station.your-station" description="Vote on Polling Day" />
       </h2>
       <address data-testid="address" className="address">
         <p>{splitAddress.slice(0, splitAddress.length - 1)}</p>
       </address>
-      <p>
-        <FormattedMessage
-          id="station.opening-hours"
-          description="Polling stations are open from 7am to 10pm on polling day."
-        />
-      </p>
+      {props.openingTimes && (
+        <p>
+          <FormattedMessage
+            id="station.opening-hours"
+            values={{
+              start: props.openingTimes.start,
+              end: props.openingTimes.end,
+            }}
+          />
+        </p>
+      )}
       {show_i18n_link && (
         <p>
           For detailed information on accessibility, see <a href={wdiv_link}>WhereDoIVote.co.uk</a>

--- a/src/StationNotFound.js
+++ b/src/StationNotFound.js
@@ -13,12 +13,17 @@ function StationNotFound(props) {
         />
       </h1>
       {props.electoral_services && <ElectoralServices es={props.electoral_services} />}
-      <p>
-        <FormattedMessage
-          id="station.opening-hours"
-          description="Polling stations are open from 7am to 10pm on polling day"
-        />
-      </p>
+      {props.openingTimes && (
+        <p>
+          <FormattedMessage
+            id="station.opening-hours"
+            values={{
+              start: props.openingTimes.start,
+              end: props.openingTimes.end,
+            }}
+          />
+        </p>
+      )}
       <Notifications list={props.notifications} />
     </section>
   );

--- a/src/tests/integration/ElectionInformationWidget.test.js
+++ b/src/tests/integration/ElectionInformationWidget.test.js
@@ -398,6 +398,43 @@ describe('ElectionInformationWidget Polling station unknown', () => {
   });
 });
 
+describe('Polling Station Opening Times', () => {
+  let getByTestId;
+  beforeEach(async () => {
+    const wrapper = renderWidget();
+    getByTestId = wrapper.getByTestId;
+  });
+
+  it('should show opening times, when station is not known', async () => {
+    let enteredPostcode = 'AA12AA';
+    mockResponse('postcode', enteredPostcode);
+    typePostcode(enteredPostcode);
+    submitPostcode();
+    let openingHours = await waitForElement(() => getByTestId('station-found'));
+    expect(openingHours).toHaveTextContent('Polling stations are open from 7am to 10pm');
+  });
+
+  it('should show opening times, even when station is not known', async () => {
+    let enteredPostcode = 'SS30AA';
+    mockResponse('postcode', enteredPostcode);
+    typePostcode(enteredPostcode);
+    act(() => {
+      submitPostcode();
+    });
+    let openingHours = await waitForElement(() => getByTestId('station-not-found'));
+    expect(openingHours).toHaveTextContent('Polling stations are open from 7am to 10pm');
+  });
+
+  it('should show custom opening times for City of London local elections', async () => {
+    let enteredPostcode = 'EC2Y8BT';
+    mockResponse('postcode', enteredPostcode);
+    typePostcode(enteredPostcode);
+    submitPostcode();
+    let openingHours = await waitForElement(() => getByTestId('station-not-found'));
+    expect(openingHours).toHaveTextContent('Polling stations are open from 8am to 8pm');
+  });
+});
+
 describe('ElectionInformationWidget Standard Widget', () => {
   beforeEach(() => {
     renderWidget();

--- a/src/translations/cy.json
+++ b/src/translations/cy.json
@@ -26,7 +26,7 @@
   "station.found": "Ble i bleidleisio",
   "station.not-found": "Ble i bleidleisio",
   "station.your-station": "Dy orsaf bleidleisio",
-  "station.opening-hours": "Mae gorsafoedd pleidleisio ar agor o 7y.b. tan 10y.h. ar ddiwrnod y bleidlais",
+  "station.opening-hours": "Mae gorsafoedd pleidleisio ar agor o {start}y.b. tan {end}y.h. ar ar ddiwrnod y bleidlais",
   "elections.unknown":"Nid ydym yn ymwybodol o unrhyw etholiadau yn dy ardal di cyn hir",
   "elections.candidates_heading":"Ymgeiswyr",
   "elections.find-out-more": "Darganfyddwch fwy yn WhoCanIVoteFor",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -26,7 +26,7 @@
   "station.found": "Where to vote",
   "station.not-found": "Where to vote",
   "station.your-station": "Vote on polling day",
-  "station.opening-hours": "Polling stations are open from 7am to 10pm on polling day",
+  "station.opening-hours": "Polling stations are open from {start}am to {end}pm on polling day",
   "elections.unknown":"We don't know of any upcoming elections in your area",
   "elections.candidates_heading":"Candidates",
   "elections.find-out-more": "Find out more at WhoCanIVoteFor",


### PR DESCRIPTION
Refs https://app.asana.com/0/1204880927741389/1208687275764619/f

This makes the widget as correct as the EC site and WDIV.

All of them fail to account for the case where there is a City of London council election and a Parl/GLA election on the same day.