### PR TITLE
match both local.city-of-london and local.city-of-london-alder

### DIFF
--- a/src/ElectionInformationWidget.js
+++ b/src/ElectionInformationWidget.js
@@ -28,7 +28,7 @@ const api = APIClientFactory();
 
 function getOpeningTimes(ballots) {
   for (const ballot of ballots) {
-    if (ballot.election_id.startsWith('local.city-of-london.')) {
+    if (ballot.election_id.startsWith('local.city-of-london')) {
       return { start: 8, end: 8 };
     }
   }


### PR DESCRIPTION
Refs https://app.asana.com/0/1204880927741389/1208953917281175/f

As written, this was matching common council elections only, but not alderman elections