### PR TITLE
remove references to custom finder

### DIFF
--- a/public/example-responses/postcode-AA15AA.json
+++ b/public/example-responses/postcode-AA15AA.json
@@ -6,7 +6,7 @@
       "date": "2018-05-03",
       "polling_station": {
         "polling_station_known": false,
-        "custom_finder": "http://www.eoni.org.uk/Offices/Postcode-Search-Results?postcode=BT28%202EY",
+        "custom_finder": null,
         "report_problem_url": null,
         "station": null
       },

--- a/public/index.html
+++ b/public/index.html
@@ -90,8 +90,7 @@
                 <li><code>local.lewisham.blackheath.2018-05-03</code> - This election is cancelled and rescheduled on 2018-05-10</li>
                 <li><code>local.lewisham.blackheath.2018-05-10</code> - This election replaces the cancelled <code>local.lewisham.blackheath.2018-05-03</code></li>
                 <li><code>parl.lewisham-east.by.2018-06-14</code> - This election is scheduled but we don't know of any candidates yet</li></ul></li>
-            <li>
-              AA15AA - Northern Ireland. This example shows the <code>custom_finder</code> key in use. We can use this to redirect users to Electoral Office for Northern Ireland's website for polling station data.</li>
+            <li>AA15AA - Northern Ireland postcode. Northern Ireland has a number of special conditions and edge cases.</li>
             <li>EH11YJ - Scotland. This example shows different registration and electoral services contact details.</li>
            </ul>
 


### PR DESCRIPTION
Refs https://app.asana.com/0/1204880927741389/1208958646411295/f
Refs https://github.com/DemocracyClub/UK-Polling-Stations/pull/8214
As far as I can tell, we never implemented this in the widget or the code has already been removed. Just a couple of bits of cleanup on the test data and docs here.