### PR TITLE
don't check candidates vs seats contested if ballot.metadata is set

### DIFF
--- a/src/BallotInfo.js
+++ b/src/BallotInfo.js
@@ -9,7 +9,9 @@ function BallotInfo(props) {
 
   return (
     <section className="BallotInfo">
-      {ballot.cancelled && ballot.candidates.length === ballot.seats_contested ? (
+      {!ballot.metadata &&
+      ballot.cancelled &&
+      ballot.candidates.length === ballot.seats_contested ? (
         <p data-testid="ballot-info">
           <FormattedMessage
             id="uncontested.equal_candidates"
@@ -24,7 +26,9 @@ function BallotInfo(props) {
             }}
           />
         </p>
-      ) : ballot.cancelled && ballot.candidates.length < ballot.seats_contested ? (
+      ) : !ballot.metadata &&
+        ballot.cancelled &&
+        ballot.candidates.length < ballot.seats_contested ? (
         <p data-testid="ballot-info">
           <FormattedMessage
             id="uncontested.fewer_candidates"
@@ -41,7 +45,8 @@ function BallotInfo(props) {
         </p>
       ) : null}
 
-      {ballot.cancelled &&
+      {!ballot.metadata &&
+      ballot.cancelled &&
       ballot.candidates.length < ballot.seats_contested &&
       ballot.candidates.length !== 0 ? (
         <p data-testid="automatic-winner">


### PR DESCRIPTION
OK. So the problem I'm trying to solve here is:

![Screenshot at 2025-02-05 15-27-23](https://github.com/user-attachments/assets/da5571e6-38d3-4478-9e05-9a8641aab9a8)

Even if there's a custom message set we're still running the candidates vs seats contested logic.

What I've done here is not great. What I really need to do is re-write this whole component to consume the cancellation reason like we do in

- https://github.com/DemocracyClub/WhoCanIVoteFor/blob/master/wcivf/apps/elections/templates/elections/includes/_cancelled_election.html
- https://github.com/DemocracyClub/ec-postcode-lookup-pages/blob/main/postcode_lookup/templates/includes/cancellation_reasons.html

but I'd quite like to bash out a quick fix for this now.

So, what I've done is just put in a bunch of checks to ignore the candidates vs seats contested checks if the metadata object is not null. This is imperfect, but will result in us saying the right thing for all future elections we have logged in EE. Then that gives us the breathing space to implement the better solution.