### PR TITLE
Cancelled elections: Render whitespace/use URL if present

### DIFF
--- a/src/BallotInfo.js
+++ b/src/BallotInfo.js
@@ -66,7 +66,22 @@ function BallotInfo(props) {
       ) : null}
 
       {ballot.cancelled && ballot.metadata ? (
-        <p data-testid="election-metadata">{ballot.metadata.cancelled_election.detail}</p>
+        <div>
+          <p style={{ whiteSpace: 'pre-wrap' }} data-testid="election-metadata">
+            {ballot.metadata.cancelled_election.detail}
+          </p>
+          {ballot.cancelled && ballot.metadata && ballot.metadata.cancelled_election.url ? (
+            <a
+              className="eiw-btn-secondary"
+              target="_blank"
+              rel="noopener noreferrer"
+              title={'Read more information'}
+              href={ballot.metadata.cancelled_election.url}
+            >
+              Read More
+            </a>
+          ) : null}
+        </div>
       ) : null}
 
       <Candidates {...props} />

--- a/src/Notifications.js
+++ b/src/Notifications.js
@@ -17,7 +17,7 @@ function Notification(props) {
         ℹ
       </span>
       <h3 className="eiw-notification-title">{props.title}</h3>
-      {props.detail && <p>{props.detail}</p>}
+      {props.detail && <p style={{ whiteSpace: 'pre-wrap' }}>{props.detail}</p>}
       {props.url && (
         <a
           className="eiw-btn-secondary"


### PR DESCRIPTION
Cancelled elections: Render whitespace/use URL if present

Refs https://app.asana.com/0/1209332771640377/1209290265508276/f
Refs https://app.asana.com/0/1209332771640377/1209332771640386/f

I've already edited the descriptions in EE to already include line breaks in the right places.

Couple of bits going on here.
1. If a notification or cancelled election details contains linbreaks, show them
2. If we have a URL use it to show a "read more" link