### PR TITLE
move everything down one heading level

### DIFF
--- a/src/AdditionalFutureElections.js
+++ b/src/AdditionalFutureElections.js
@@ -5,9 +5,9 @@ import PollingDate from './PollingDate';
 function AdditionalFutureElections(props) {
   return (
     <>
-      <h1 className="eiw-header">
+      <h2 className="eiw-header">
         <FormattedMessage id="future.more-elections" description="More elections in your area" />
-      </h1>
+      </h2>
       {props.dates.map((date, i) => (
         <PollingDate key={`date-${i}`} single={false} date={date} {...props} />
       ))}

--- a/src/AddressPicker.js
+++ b/src/AddressPicker.js
@@ -40,11 +40,11 @@ class AddressPicker extends React.Component {
     return (
       <form className="AddressPicker" data-testid="address-selector">
         <div className="form-group">
-          <h1>
+          <h2>
             <label id="choose-address" className="form-label-bold" htmlFor="id_address">
               {formatMessage({ id: 'address.choose-address' })}
             </label>
-          </h1>
+          </h2>
           <select
             aria-labelledby="id_address"
             value={this.state.value}

--- a/src/AdvanceVoting.js
+++ b/src/AdvanceVoting.js
@@ -61,9 +61,9 @@ function AdvanceVoting(props) {
           description="Your council is trialling a system that allows you to vote in person before polling day. You can vote in advance at this location, or vote at your polling station as normal on polling day."
         />
       </p>
-      <h2 className="eiw-secondary-header" data-testid="advance-voting-station">
+      <h3 className="eiw-secondary-header" data-testid="advance-voting-station">
         <FormattedMessage id="advance-voting-station.found" description="Vote before polling day" />
-      </h2>
+      </h3>
       <p>
         <FormattedMessage
           id="advance-voting-station.your-station"

--- a/src/Ballot.js
+++ b/src/Ballot.js
@@ -19,7 +19,7 @@ function Ballot(props) {
   }
   return (
     <li className="Ballot" data-testid={ballot.ballot_paper_id}>
-      <h2 className={`eiw-secondary-header ${!candidatesVerified && 'full-width'}`}>
+      <h3 className={`eiw-secondary-header ${!candidatesVerified && 'full-width'}`}>
         {ballot.cancelled ? (
           <span role="img" aria-label="Red cross">
             ❌
@@ -30,7 +30,7 @@ function Ballot(props) {
           </span>
         )}{' '}
         {ballot.election_name + ': ' + ballot.post_name + ' ' + divisionType}
-      </h2>
+      </h3>
       <BallotInfo {...props} />
     </li>
   );

--- a/src/CandidateList.js
+++ b/src/CandidateList.js
@@ -12,12 +12,12 @@ function CandidateList(props) {
         <ul>
           {candidates.map((candidate) => (
             <li className="CandidateListItem" key={candidate.person.ynr_id}>
-              <h4 className={`candidate-name party-${candidate.party.party_id.split(':')[1]}`}>
+              <h5 className={`candidate-name party-${candidate.party.party_id.split(':')[1]}`}>
                 {candidate.person.name}
-              </h4>{' '}
-              <h5 className={`party-name party-${candidate.party.party_id.split(':')[1]}`}>
+              </h5>{' '}
+              <h6 className={`party-name party-${candidate.party.party_id.split(':')[1]}`}>
                 {candidate.party.party_name}
-              </h5>
+              </h6>
             </li>
           ))}
         </ul>
@@ -27,7 +27,7 @@ function CandidateList(props) {
         <ul>
           {candidates.map((candidate) => (
             <li className="CandidateListItem" key={candidate.person.ynr_id}>
-              <h4 className={`candidate-name party-${candidate.party.party_id.split(':')[1]}`}>
+              <h5 className={`candidate-name party-${candidate.party.party_id.split(':')[1]}`}>
                 <a
                   data-testid="candidate-link"
                   title={formatMessage({ id: 'general.read-more-info-candidate' })}
@@ -37,11 +37,11 @@ function CandidateList(props) {
                 >
                   {candidate.person.name}
                 </a>
-              </h4>{' '}
-              <h5 className={`party-name party-${candidate.party.party_id.split(':')[1]}`}>
+              </h5>{' '}
+              <h6 className={`party-name party-${candidate.party.party_id.split(':')[1]}`}>
                 {candidate.party.party_name}
                 <PartyToolTip candidate={candidate} />
-              </h5>
+              </h6>
             </li>
           ))}
         </ul>

--- a/src/Candidates.js
+++ b/src/Candidates.js
@@ -11,7 +11,9 @@ function Candidates(props) {
     <>
       {candidatesVerified && !ballot.cancelled && (
         <section className="Candidates" data-testid="candidates">
-          <h3>{formatMessage({ id: 'elections.candidates_heading' })}</h3>
+          <h4 className="eiw-secondary-header">
+            {formatMessage({ id: 'elections.candidates_heading' })}
+          </h4>
           {props.ballot.voting_system.uses_party_lists === true ? (
             <PartyList {...props} />
           ) : (

--- a/src/NoUpcomingElection.js
+++ b/src/NoUpcomingElection.js
@@ -5,12 +5,12 @@ import { FormattedMessage } from 'react-intl';
 function NoUpcomingElection(props) {
   return (
     <div className="NoUpcomingElection">
-      <h1 className="eiw-header">
+      <h2 className="eiw-header">
         <FormattedMessage
           id="elections.unknown"
           description="We don't know of any upcoming elections in your area"
         />
-      </h1>
+      </h2>
       <Notifications list={props.notifications} />
     </div>
   );

--- a/src/Notifications.js
+++ b/src/Notifications.js
@@ -16,7 +16,7 @@ function Notification(props) {
       <span role="img" alt="information">
         ℹ
       </span>
-      <h3 className="eiw-notification-title">{props.title}</h3>
+      <h4 className="eiw-notification-title">{props.title}</h4>
       {props.detail && <p style={{ whiteSpace: 'pre-wrap' }}>{props.detail}</p>}
       {props.url && (
         <a

--- a/src/PartyList.js
+++ b/src/PartyList.js
@@ -26,9 +26,9 @@ function PartyList(props) {
       <ul data-testid={`ul-${props.ballot.ballot_paper_id}`}>
         {parties.map((party) => (
           <li className="PartyListItem" key={party.party_id}>
-            <h4 className={`candidate-name party-${party.party_id.split(':')[1]}`}>
+            <h5 className={`candidate-name party-${party.party_id.split(':')[1]}`}>
               {party.party_name}
-            </h4>
+            </h5>
           </li>
         ))}
       </ul>

--- a/src/PollingDate.js
+++ b/src/PollingDate.js
@@ -42,9 +42,9 @@ function PollingDate(props) {
     >
       {props.single && (
         <div>
-          <h1 data-testid={`title-date-${date.date}`} className="eiw-header">
+          <h2 data-testid={`title-date-${date.date}`} className="eiw-header">
             {dayMonthYear}
-          </h1>
+          </h2>
           {activeBallots.length > 0 && (
             <p>
               <FormattedMessage
@@ -90,9 +90,9 @@ function PollingDate(props) {
       )}
       {voter_id_requirements && (
         <div>
-          <h3>
+          <h4 className="eiw-secondary-header">
             <FormattedMessage id="voter_id_requirements.header" description="Voter ID" />
-          </h3>
+          </h4>
         </div>
       )}
       {voter_id_requirements === 'EA-2022' && (

--- a/src/PollingStation.js
+++ b/src/PollingStation.js
@@ -24,9 +24,9 @@ function PollingStation(props) {
   });
   return (
     <section className="PollingStation" data-testid="station-found">
-      <h2 className="eiw-secondary-header">
+      <h3 className="eiw-secondary-header">
         <FormattedMessage id="station.your-station" description="Vote on Polling Day" />
-      </h2>
+      </h3>
       <address data-testid="address" className="address">
         <p>{splitAddress.slice(0, splitAddress.length - 1)}</p>
       </address>

--- a/src/PostcodeSelector.js
+++ b/src/PostcodeSelector.js
@@ -40,11 +40,11 @@ function PostcodeSelector(props) {
   return (
     <form className="PostcodeSelector" onSubmit={handleSubmit} data-testid="postcode-selector">
       <div className="form-group">
-        <h1>
+        <h2>
           <label className="form-label-bold" htmlFor="postcode">
             <FormattedMessage id="postcode.enter-postcode" description="Enter your postcode" />
           </label>
-        </h1>
+        </h2>
 
         <input
           value={formValue}

--- a/src/StationFound.js
+++ b/src/StationFound.js
@@ -3,9 +3,9 @@ import { FormattedMessage } from 'react-intl';
 
 function StationFound() {
   return (
-    <h1 className="eiw-header">
+    <h2 className="eiw-header">
       <FormattedMessage id="station.found" description="Where to vote" />
-    </h1>
+    </h2>
   );
 }
 

--- a/src/StationNotFound.js
+++ b/src/StationNotFound.js
@@ -6,12 +6,12 @@ import ElectoralServices from './ElectoralServices';
 function StationNotFound(props) {
   return (
     <section className="StationNotFound" data-testid="station-not-found">
-      <h1 className="eiw-header">
+      <h2 className="eiw-header">
         <FormattedMessage
           id="station.not-found"
           description="We don't know where you should vote"
         />
-      </h1>
+      </h2>
       {props.electoral_services && <ElectoralServices es={props.electoral_services} />}
       {props.openingTimes && (
         <p>

--- a/src/dc-widget-styles.css
+++ b/src/dc-widget-styles.css
@@ -199,7 +199,7 @@
 # Typography
 --------------------------------------------------------------*/
 
-h1.eiw-header,
+h2.eiw-header,
 .ElectionInformationWidget .form-label-bold {
   font-weight: bold;
   display: block;
@@ -213,6 +213,8 @@ h1.eiw-header,
   font-size: var(--eiw-font-size-default);
   color: var(--eiw-body-text-colour);
   font-family: var(--eiw-sanserif-font);
+  margin-top: 1rem;
+  margin-bottom: 1rem;
 }
 
 .ElectionInformationWidget .form-label-reduced {
@@ -353,7 +355,7 @@ a.eiw-btn-seconday:hover {
 # Form styles
 --------------------------------------------------------------*/
 
-.form-group h1 {
+.form-group h2 {
   margin: 0;
 }
 .ElectionInformationWidget .form-control {
@@ -629,7 +631,7 @@ ul.inline-list li.Ballot:after {
   clear: both;
 }
 
-ul.inline-list h2.full-width {
+ul.inline-list h3.full-width {
   width: 100%;
 }
 

--- a/src/ec-widget-styles.css
+++ b/src/ec-widget-styles.css
@@ -201,7 +201,7 @@
 # Typography
 --------------------------------------------------------------*/
 
-h1.eiw-header,
+h2.eiw-header,
 .ElectionInformationWidget .form-label-bold {
   font-weight: bold;
   display: block;
@@ -217,6 +217,8 @@ h1.eiw-header,
   font-size: var(--eiw-font-size-default);
   color: var(--eiw-body-text-colour);
   font-family: var(--eiw-sanserif-font);
+  margin-top: 1rem;
+  margin-bottom: 1rem;
 }
 
 .ElectionInformationWidget .form-label-reduced {
@@ -343,7 +345,7 @@ a.eiw-btn-seconday:hover {
 # Form styles
 --------------------------------------------------------------*/
 
-.form-group h1 {
+.form-group h2 {
   margin: 0;
 }
 .ElectionInformationWidget .form-control {
@@ -618,7 +620,7 @@ ul.inline-list li.Ballot:after {
   clear: both;
 }
 
-ul.inline-list h2.full-width {
+ul.inline-list h3.full-width {
   width: 100%;
 }
 

--- a/src/tests/integration/ElectionInformationWidget.test.js
+++ b/src/tests/integration/ElectionInformationWidget.test.js
@@ -518,10 +518,10 @@ describe('ElectionInformationWidget Accessibility', () => {
     const wrapper = renderWidget();
     getByTestId = wrapper.getByTestId;
   });
-  it('should include an h1 at the top level of the postcode selector', async () => {
+  it('should include an h2 at the top level of the postcode selector', async () => {
     const PostcodeForm = await waitForElement(() => getByTestId('postcode-selector'));
-    let h1 = PostcodeForm.querySelector('h1');
-    expect(PostcodeForm).toContainElement(h1);
+    let h2 = PostcodeForm.querySelector('h2');
+    expect(PostcodeForm).toContainElement(h2);
   });
   it('should accept Enter instead of clicking the button', async () => {
     const PostcodeForm = await waitForElement(() => getByTestId('postcode-selector'));
@@ -565,7 +565,7 @@ describe('ElectionInformationWidget Accessibility', () => {
       submitPostcode();
     });
     let stationNotFound = await waitForElement(() => getByTestId('station-not-found'));
-    const accessibleTitle = `<h1 class="eiw-header">Where to vote</h1>`;
+    const accessibleTitle = `<h2 class="eiw-header">Where to vote</h2>`;
     expect(stationNotFound).toContainHTML(accessibleTitle);
   });
 


### PR DESCRIPTION
Refs https://app.asana.com/0/1204880927741389/1209594651255453/f

This PR moves everything down one heading level so the highest level of heading is h2 and everything else is one level lower than that.
There's also a couple of bits of CSS fiddling to get everything to display roughly the same after that change.
We already render everything inside a `<section>` so no change needed there.

I've tested this with both the EC and DC-branded versions