### PR TITLE
handle missing council

### DIFF
--- a/src/ElectionInformationWidget.js
+++ b/src/ElectionInformationWidget.js
@@ -124,6 +124,7 @@ function ElectionInformationWidget(props) {
       }
       // Hide parish notifications for Northern Ireland and London
       if (
+        response.electoral_services &&
         response.electoral_services.identifiers &&
         (response.electoral_services.postcode.startsWith('BT') ||
           response.electoral_services.identifiers.some((id) => id.startsWith('E09')))


### PR DESCRIPTION
This is a fix for a bug introduced in https://github.com/DemocracyClub/WhereDoIVote-Widget/pull/715 I noticed it while I was working on https://github.com/DemocracyClub/WhereDoIVote-Widget/pull/716

You can reproduce this issue by going to https://widget.wheredoivote.co.uk/demo.html and entering a postcode like BA12 6NE. The key thing about this postcode is that it contains addresses in >1 local authority so the `electoral_services` property is `null` in the address picker response because we don't know what council the user is in until we know their address.

This PR handles that case.