### PR TITLE
remove or prefix IDs to prevent clashing

### DIFF
--- a/src/AddressPicker.js
+++ b/src/AddressPicker.js
@@ -41,7 +41,7 @@ class AddressPicker extends React.Component {
       <form className="AddressPicker" data-testid="address-selector">
         <div className="form-group">
           <h2>
-            <label id="choose-address" className="form-label-bold" htmlFor="id_address">
+            <label className="form-label-bold" htmlFor="id_address">
               {formatMessage({ id: 'address.choose-address' })}
             </label>
           </h2>

--- a/src/Branding.js
+++ b/src/Branding.js
@@ -4,7 +4,7 @@ import { injectIntl } from 'react-intl';
 function ErrorMessageTemplate(props) {
   const { formatMessage } = props.intl;
   return (
-    <div className="ErrorMessage" id="eiw-error" role="alert" aria-live="assertive">
+    <div className="ErrorMessage" data-testid="eiw-error" role="alert" aria-live="assertive">
       {props.currentError && formatMessage({ id: props.currentError })}
     </div>
   );

--- a/src/PartyToolTip.js
+++ b/src/PartyToolTip.js
@@ -7,11 +7,11 @@ function PartyToolTip(props) {
 
   if (prevParties) {
     return (
-      <div id="ToolTipContainer">
+      <div id="f48a9a8a31-ToolTipContainer">
         <button
           data-tip="Other party affiliations"
           data-event="click"
-          data-for="PartyToolTip"
+          data-for="f48a9a8a31-PartyToolTip"
           data-offset="{'top': 10}"
           role="note"
           aria-label="PartyToolTip"
@@ -19,7 +19,7 @@ function PartyToolTip(props) {
           i
         </button>
 
-        <ReactTooltip id="PartyToolTip" effect="solid" type="info">
+        <ReactTooltip id="f48a9a8a31-PartyToolTip" effect="solid" type="info">
           <FormattedMessage
             id="candidate.affiliations"
             description="Affiliated with the following parties in the last 12 months:"

--- a/src/PostcodeSelector.js
+++ b/src/PostcodeSelector.js
@@ -50,7 +50,7 @@ function PostcodeSelector(props) {
           value={formValue}
           onChange={handleFormChange}
           type="text"
-          id="postcode"
+          data-testid="postcode"
           name="postcode"
           className="form-control"
         />

--- a/src/dc-widget-styles.css
+++ b/src/dc-widget-styles.css
@@ -800,13 +800,13 @@ button.toggled.arrow.inline-button::after {
 }
 
 
-#ToolTipContainer {
+#f48a9a8a31-ToolTipContainer {
   position: absolute;
   display: inline-block;
   padding: 0.075em 0 0.075em 0.25em;
 }
 
-#ToolTipContainer button {
+#f48a9a8a31-ToolTipContainer button {
   padding: 0 !important;
   text-align: center;
   width: 1.25em;
@@ -817,9 +817,10 @@ button.toggled.arrow.inline-button::after {
   font-weight: bold;
 }
 
-#PartyToolTip {
+#f48a9a8a31-PartyToolTip {
   width:100px;
 }
+
 /* dc-design system table styles  */
 .ds-table {
   overflow-x: auto;

--- a/src/tests/integration/ElectionInformationWidget.test.js
+++ b/src/tests/integration/ElectionInformationWidget.test.js
@@ -34,7 +34,7 @@ describe('ElectionInformationWidget General', () => {
 
   it('should give error message when no postcode is entered', async () => {
     submitPostcode();
-    const ErrorMessage = await waitForElement(() => document.querySelector('#eiw-error'));
+    const ErrorMessage = await waitForElement(() => getByTestId('eiw-error'));
 
     expect(ErrorMessage).toHaveTextContent(en_messages['postcode.errors.invalid-postcode']);
   });
@@ -43,7 +43,7 @@ describe('ElectionInformationWidget General', () => {
     let enteredPostcode = 'aaaa';
     typePostcode(enteredPostcode);
     submitPostcode();
-    const ErrorMessage = await waitForElement(() => document.querySelector('#eiw-error'));
+    const ErrorMessage = await waitForElement(() => getByTestId('eiw-error'));
     expect(ErrorMessage).toHaveTextContent(en_messages['postcode.errors.invalid-postcode']);
   });
 
@@ -204,13 +204,15 @@ describe('ElectionInformationWidget Electoral Services', () => {
 });
 
 describe('ElectionInformationWidget Welsh Widget', () => {
+  let getByTestId;
   beforeEach(async () => {
-    renderWelshWidget();
+    const wrapper = renderWelshWidget();
+    getByTestId = wrapper.getByTestId;
   });
 
   it('should give error message when no postcode is entered', async () => {
     submitPostcode();
-    const newContent = await waitForElement(() => document.querySelector('#eiw-error'));
+    const newContent = await waitForElement(() => getByTestId('eiw-error'));
 
     expect(newContent).toHaveTextContent(cy_messages['postcode.errors.invalid-postcode']);
   });
@@ -219,7 +221,7 @@ describe('ElectionInformationWidget Welsh Widget', () => {
     let enteredPostcode = 'aaaa';
     typePostcode(enteredPostcode);
     submitPostcode();
-    const newContent = await waitForElement(() => document.querySelector('#eiw-error'));
+    const newContent = await waitForElement(() => getByTestId('eiw-error'));
     expect(newContent).toHaveTextContent(cy_messages['postcode.errors.invalid-postcode']);
   });
 });
@@ -240,7 +242,7 @@ describe('ElectionInformationWidget Toggleable English Widget', () => {
   it('should let you translate the widget to Welsh', async () => {
     chooseLanguage('cy');
     submitPostcode();
-    const translatedContent = await waitForElement(() => document.querySelector('#eiw-error'));
+    const translatedContent = await waitForElement(() => getByTestId('eiw-error'));
     expect(translatedContent).toHaveTextContent(cy_messages['postcode.errors.invalid-postcode']);
   });
 
@@ -248,7 +250,9 @@ describe('ElectionInformationWidget Toggleable English Widget', () => {
     chooseLanguage('cy');
     submitPostcode();
     chooseLanguage('en');
-    const translatedContent = await waitForElement(() => container.querySelector('#eiw-error'));
+    const translatedContent = await waitForElement(() =>
+      container.querySelector('[data-testid="eiw-error"]')
+    );
     expect(translatedContent).toHaveTextContent(en_messages['postcode.errors.invalid-postcode']);
   });
 });
@@ -269,7 +273,7 @@ describe('ElectionInformationWidget Toggleable Welsh Widget', () => {
   it('should let you translate the widget to English', async () => {
     chooseLanguage('en');
     submitPostcode();
-    const translatedContent = await waitForElement(() => document.querySelector('#eiw-error'));
+    const translatedContent = await waitForElement(() => getByTestId('eiw-error'));
     expect(translatedContent).toHaveTextContent(en_messages['postcode.errors.invalid-postcode']);
   });
 
@@ -277,7 +281,9 @@ describe('ElectionInformationWidget Toggleable Welsh Widget', () => {
     chooseLanguage('en');
     submitPostcode();
     chooseLanguage('cy');
-    const translatedContent = await waitForElement(() => container.querySelector('#eiw-error'));
+    const translatedContent = await waitForElement(() =>
+      container.querySelector('[data-testid="eiw-error"]')
+    );
     expect(translatedContent).toHaveTextContent(cy_messages['postcode.errors.invalid-postcode']);
   });
 });

--- a/src/tests/utils/test.js
+++ b/src/tests/utils/test.js
@@ -24,7 +24,7 @@ export const renderWithReactIntl = (component) => {
 };
 
 export const typePostcode = (postcode) => {
-  fireEvent.change(document.querySelector('#postcode'), {
+  fireEvent.change(document.querySelector('[data-testid="postcode"]'), {
     target: { value: postcode },
   });
 };


### PR DESCRIPTION
We actually don't use IDs very much in this project so my approach here is lets remove them completely where possible. Can't have clashing IDs if we delete the IDs.

<img width="1200" height="784" alt="1_9y6b-UKSVlfJNVDwtTVIKw-2522131194" src="https://github.com/user-attachments/assets/13a9df4c-5e66-444d-a2c2-3cebff71a3eb" />

There is one place where I have failed in this though, which is the tooltip for previous party affiliations. We have to use an id attribute here https://github.com/ReactTooltip/react-tooltip/blob/master/README.md#:~:text=Note,work%20without%20it!
In that case, I've just added some junk to the IDs to make a clash very unlikely.