### PR TITLE
format Welsh dates in Chrome without polyfill

### DIFF
--- a/src/AdvanceVoting.js
+++ b/src/AdvanceVoting.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { Notifications } from './Notifications';
 import { Directions } from './Directions';
+import { formatDate } from './utils';
 
 function AdvanceVoting(props) {
   let splitAddress = [];
@@ -32,14 +33,10 @@ function AdvanceVoting(props) {
           </tr>
 
           {props.advance_voting_station.opening_times.map((opening_time, index) => {
-            let advanceVotingDate = new Date(opening_time[0]);
-            let dayMonthYear = advanceVotingDate.toLocaleDateString(props.locale, {
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric',
-            });
-            let openingTime = opening_time[1].substring(0, 5);
-            let closingTime = opening_time[2].substring(0, 5);
+            const advanceVotingDate = new Date(opening_time[0]);
+            const dayMonthYear = formatDate(advanceVotingDate, props.locale);
+            const openingTime = opening_time[1].substring(0, 5);
+            const closingTime = opening_time[2].substring(0, 5);
             return (
               <tr key={index}>
                 <td>{dayMonthYear}</td>

--- a/src/BallotInfo.js
+++ b/src/BallotInfo.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Candidates from './Candidates';
-import getWordsFromNumber from './utils';
+import { getWordsFromNumber } from './utils';
 import { FormattedMessage } from 'react-intl';
 
 function BallotInfo(props) {

--- a/src/PollingDate.js
+++ b/src/PollingDate.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
-import getWordsFromNumber from './utils';
+import { getWordsFromNumber, formatDate } from './utils';
 import Ballot from './Ballot';
 
 /*
@@ -12,14 +12,8 @@ with javascript's built-in Date().
 */
 function PollingDate(props) {
   const date = props.date;
-  let electionDate = new Date(date.date);
-  let dayMonthYear = electionDate.toLocaleDateString(props.locale, {
-    weekday: 'long',
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  });
-
+  const electionDate = new Date(date.date);
+  const dayMonthYear = formatDate(electionDate, props.locale);
   const activeBallots = date.ballots.filter((b) => !b.cancelled);
 
   // Loop through all ballots and see if any of the requires_voter_id

--- a/src/tests/unit/utils.test.js
+++ b/src/tests/unit/utils.test.js
@@ -1,0 +1,29 @@
+import { formatDateCy } from '../../utils';
+
+describe('formatDateCy', () => {
+  it('Should match behaviour of toLocaleDateString', () => {
+    /*
+    Node ships with a cy language pack so under test
+    we can confirm our custom function is right
+    by looping over a year's worth of dates
+    and asserting that the output of
+    formatDateCy()
+    matches the output of
+    toLocaleDateString()
+    with the relevant options
+    */
+    const start = new Date('2026-01-01');
+    for (let i = 0; i < 365; i++) {
+      const date = new Date(start);
+      date.setDate(start.getDate() + i);
+      const expectedDateStr = date.toLocaleDateString('cy', {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      });
+      const outDateStr = formatDateCy(date);
+      expect(outDateStr).toEqual(expectedDateStr);
+    }
+  });
+});

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,4 +5,52 @@ function getWordsFromNumber(n, translations) {
   return n;
 }
 
-export default getWordsFromNumber;
+function formatDateCy(date) {
+  // days are 0-indexed, starting from Sunday
+  const days = [
+    'Dydd Sul',
+    'Dydd Llun',
+    'Dydd Mawrth',
+    'Dydd Mercher',
+    'Dydd Iau',
+    'Dydd Gwener',
+    'Dydd Sadwrn',
+  ];
+
+  // months are 0-indexed, starting from January
+  const months = [
+    'Ionawr',
+    'Chwefror',
+    'Mawrth',
+    'Ebrill',
+    'Mai',
+    'Mehefin',
+    'Gorffennaf',
+    'Awst',
+    'Medi',
+    'Hydref',
+    'Tachwedd',
+    'Rhagfyr',
+  ];
+
+  return `${days[date.getDay()]}, ${date.getDate()} ${
+    months[date.getMonth()]
+  } ${date.getFullYear()}`;
+}
+
+function formatDate(date, locale) {
+  let formattedDate = date.toLocaleDateString(locale, {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+
+  if (locale == 'cy' && Intl.DateTimeFormat.supportedLocalesOf('cy').length == 0) {
+    formattedDate = formatDateCy(date);
+  }
+
+  return formattedDate;
+}
+
+export { getWordsFromNumber, formatDateCy, formatDate };


### PR DESCRIPTION
The polyfill approach had 2 quite annoying downsides:

1. It massively increased the bundle size for the sake of one thing we wanted to use it for.
2. Using a polyfill mutated the global `window.Intl` object, which is a bit rude of us. Lets be nice to the parent page we are being embedded in.