### PR TITLE
add box shadow to focus ring

### DIFF
--- a/src/dc-widget-styles.css
+++ b/src/dc-widget-styles.css
@@ -122,6 +122,8 @@
 *:focus {
   outline: 4px solid var(--eiw-outline-focus);
   box-shadow: 0 0 0 6px var(--eiw-body-text-colour);
+  appearance: none;
+  -moz-appearance: none;
 }
 
 .screen-reader-text {

--- a/src/dc-widget-styles.css
+++ b/src/dc-widget-styles.css
@@ -121,6 +121,7 @@
 .ElectionInformationWidget select:focus,
 *:focus {
   outline: 4px solid var(--eiw-outline-focus);
+  box-shadow: 0 0 0 6px var(--eiw-body-text-colour);
 }
 
 .screen-reader-text {

--- a/src/ec-widget-styles.css
+++ b/src/ec-widget-styles.css
@@ -137,6 +137,9 @@
 .ElectionInformationWidget select:focus,
 *:focus {
   outline: 4px solid var(--eiw-outline-focus);
+  box-shadow: 0 0 0 6px var(--eiw-body-text-colour);
+  appearance: none;
+  -moz-appearance: none;
 }
 
 .screen-reader-text {


### PR DESCRIPTION
Background on this one is: We've had a council say there's insufficient contrast on the form field. Having had a bit of a dig, I think the issue is the yellow focus ring. I tried changing the focus ring colour to some different colours from the DC palette
https://democracyclub.github.io/design-system/basics/colors/
The all looked a bit rubbish tbh.

I think the solution I have settled on is adding a couple of pixels of box shadow to the focus ring, so its still mostly yellow but we add a darker outline to give you the contrast.

That gives you..

before

<img width="629" height="252" alt="Screenshot at 2026-06-17 15-23-06" src="https://github.com/user-attachments/assets/c57bf2ad-d0bf-41df-8ab6-084de59899fe" />

after

<img width="635" height="263" alt="Screenshot at 2026-06-17 15-22-41" src="https://github.com/user-attachments/assets/c8e54509-8cd9-454b-a25c-a18e110aa474" />

I think that's the least-worst thing I've tried, but open to other options. We could completely drop the focus ring. Focus ring can't have insufficient contrast if you don't have a focus ring [rollsafe] but I feel like that is throwing the baby out with the bathwater a bit.